### PR TITLE
Make sure that group was shown at checkout

### DIFF
--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1058,16 +1058,28 @@ function pmpro_add_user_fields_to_email( $email ) {
 			// Get field group settings.
 			$fields_groups = pmpro_get_user_fields_settings();
 
+			// Remove any field groups that don't show on checkout.
+			foreach ( $fields_groups as $key => $group ) {
+				if ( $group->checkout !== 'yes' ) {
+					unset( $fields_groups[ $key ] );
+				}
+			}
+
+			// Remove any field groups that are not for the membership level that was purchased.
+			if ( ! empty( $email->data['membership_id'] ) ) {
+				$level_id = $email->data['membership_id'];
+				foreach ( $fields_groups as $key => $group ) {
+					if ( ! empty( $group->levels ) && ! in_array( $level_id, $group->levels ) ) {
+						unset( $fields_groups[ $key ] );
+					}
+				}
+			}
+
 			//add to bottom of email
 			if ( ! empty( $fields_groups ) ) {
 				$email->body .= "<p>" . __( 'Extra Fields:', 'paid-memberships-pro' ) . "<br />";
 				//cycle through groups
 				foreach( $fields_groups as $group ) {
-
-					// Skip any field groups that don't show on checkout.
-					if ( $group->checkout !== 'yes' ) {
-						continue;
-					}
 
 					// Get the groups name so we can grab it from the associative array.
 					$group_name = $group->name;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1. Prevent showing field groups that are restricted to a membership level other than the one that was purchased
2. Prevent showing the "Extra Fields" header if there are no fields to be shown (this could be the case if no groups are set to be shown at checkout or if all groups are restricted to a different level)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
